### PR TITLE
support force flag in client & API and dry_run in API

### DIFF
--- a/releasify/cli.py
+++ b/releasify/cli.py
@@ -17,11 +17,15 @@ if __name__ == '__main__':
     parser.add_argument('type', help='The type of release')
     parser.add_argument('-d', '--dryrun', help='Perform a dry run (doesn\'t create the release)', 
                         action='store_true')
+    parser.add_argument('-f', '--force', help='Create a release even if there aren\'t any commits since the last release', 
+                        action='store_true')
     args = parser.parse_args()
 
     # TODO: let user & password be passed in via optional CLI args
     client = Client(os.getenv('GITHUB_USER'), os.getenv('GITHUB_PASSWORD'))
-    result = client.create_release(args.owner, args.repo, args.type, dry_run=args.dryrun)
+    result = client.create_release(
+        args.owner, args.repo, args.type, dry_run=args.dryrun, force_release=args.force
+    )
 
     if result['ok']:
         print(f'Release name: {result["tag_name"]}')

--- a/releasify/client.py
+++ b/releasify/client.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from pprint import pprint
+from types import SimpleNamespace
 
 import requests
 
@@ -12,7 +13,8 @@ API_ROOT = 'https://api.github.com/'
 
 
 class ClientError(Exception):
-    pass
+    def __init__(self, message=None):
+        self.message = message
 
 
 class UnauthorizedError(ClientError):
@@ -24,7 +26,8 @@ class NotFoundError(ClientError):
 
 
 class NoCommitsError(ClientError):
-    pass
+    def __init__(self):
+        self.message = 'No commits since last release'
 
 
 class Client(object):
@@ -111,7 +114,8 @@ class Client(object):
 
         if dry_run:
             status_code = 201
-            resp = {'status_code': status_code}
+            # Use SimpleNamespace so we get attribute access
+            resp = SimpleNamespace(**{'status_code': status_code})
         else:
             resp = self._post(url, payload)
             status_code = resp.status_code

--- a/releasify/client.py
+++ b/releasify/client.py
@@ -80,13 +80,15 @@ class Client(object):
         base = release or self.get_latest_release_tag(owner, repo)
         return self.compare_commits(owner, repo, base, head).json()['commits']
 
-    def create_release(self, owner, repo, release_type, draft=False, prerelease=True, dry_run=False):
+    def create_release(
+        self, owner, repo, release_type, draft=False, prerelease=True, dry_run=False, force_release=False
+    ):
         # TODO: this should be an optional arg
         target_branch = self.get_default_branch(owner, repo)
 
         # TODO: use Enum for release type
         commits = self.get_commits_since_release(owner, repo, target_branch)
-        if len(commits) == 0:
+        if len(commits) == 0 and not force_release:
             raise NoCommitsError()
 
         merge_messages = get_merge_messages(commits)

--- a/releasify/utils.py
+++ b/releasify/utils.py
@@ -3,13 +3,12 @@ import re
 pattern = re.compile(r'[vV](?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)')
 
 
-"""Increment a semantic version string
-
-Returns:
-	str -- The incremented semantic version string
-"""
-
 def increment_version(version, release_type):
+	"""Increment a semantic version string
+
+	Returns:
+		str -- The incremented semantic version string
+	"""
 	parts = pattern.match(version).groupdict()
 	major = int(parts['major'])
 	minor = int(parts['minor'])
@@ -26,3 +25,7 @@ def increment_version(version, release_type):
 		patch += 1
 	
 	return f'v{major}.{minor}.{patch}'
+
+
+def boolify(s):
+	return str(s).lower() in ['yes', 'y', 'true', '1']

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,4 +59,15 @@ def test_create_release_exits_if_no_commits_since_last_release():
     client.get_commits_since_release = MagicMock(return_value=[])
     
     with pytest.raises(NoCommitsError):
-        client.create_release('owner', 'repo', 'major')
+        client.create_release('owner', 'repo', 'major', dry_run=True)
+
+
+def test_create_release_with_force_release_flag_doesnt_raise():
+    client = Client('user', 'password')
+    client.get_default_branch = MagicMock(return_value='master')
+    client.get_latest_release_tag = MagicMock(return_value='v1.0.0')
+    client.get_commits_since_release = MagicMock(return_value=[])
+    
+    resp = client.create_release('owner', 'repo', 'major', dry_run=True, force_release=True)
+
+    assert resp['ok'] is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from releasify.utils import increment_version
+from releasify.utils import (boolify, increment_version)
 
 
 @pytest.mark.parametrize("test_input,expected", [
@@ -28,3 +28,21 @@ def test_increment_minor_version(test_input, expected):
 ])
 def test_increment_patch_version(initial_version, expected):
     assert increment_version(initial_version, 'patch') == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    ('y', True),
+    ('Y', True),
+    ('yes', True),
+    ('YES', True),
+    ('Yes', True),
+    ('true', True),
+    ('True', True),
+    (1, True),
+    ('1', True),
+    ('no', False),
+    ('N', False),
+    ('false', False),
+])
+def test_boolify(input, expected):
+    assert boolify(input) == expected


### PR DESCRIPTION
Resolves #2 
- adds a `force_release` flag that'll force creating the release even if there haven't been any commits since the last release
- adds support for the `dry_run` flag in the API